### PR TITLE
add libnotify for runelite

### DIFF
--- a/com.jagexlauncher.JagexLauncher.yml
+++ b/com.jagexlauncher.JagexLauncher.yml
@@ -42,7 +42,7 @@ modules:
     config-opts:
       - -Dman=false
       - -Dgtk_doc=false
-      - -Ddocbook_docs=false
+      - -Ddocbook_docs=disabled
     cleanup:
       - /include
       - /lib/pkgconfig

--- a/com.jagexlauncher.JagexLauncher.yml
+++ b/com.jagexlauncher.JagexLauncher.yml
@@ -17,6 +17,7 @@ finish-args:
   - --share=network
   - --allow=multiarch
   - --allow=devel
+  - --talk-name=org.freedesktop.Notifications
 sdk-extensions:
   - org.freedesktop.Sdk.Compat.i386
   - org.freedesktop.Sdk.Extension.openjdk11
@@ -36,6 +37,24 @@ add-extensions:
     download-if: active-gl-driver
     enable-if: active-gl-driver
 modules:
+  - name: libnotify
+    buildsystem: meson
+    config-opts:
+      - -Dman=false
+      - -Dgtk_doc=false
+      - -Ddocbook_docs=false
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - /lib/debug
+      - /lib/girepository-1.0
+      - /share/gtk-doc
+      - /share/gir-1.0
+    sources:
+      - type: git
+        url: https://github.com/GNOME/libnotify.git
+        tag: 0.8.3
+        commit: 6083790f9e0f1827147ecd8799c4dced0e86a877
   - name: openjdk
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
This PR fixes the issue found in Discord: https://discord.com/channels/828918474784768010/1214573355819343902

`libnotify` is required along with the appropriate permission to allow RuneLite to send notifications.