### PR TITLE
Fail bash script on failure

### DIFF
--- a/install-jagex-launcher-repo.sh
+++ b/install-jagex-launcher-repo.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 FREEDESKTOP_VERSION="23.08"
 
+set -e
+
 HAS_NVIDIA=0
 if [[ -f /proc/driver/nvidia/version ]]; then
     HAS_NVIDIA=1


### PR DESCRIPTION
Adding the "set -e" flag to fail on command failure (such as if flatpak isn't installed)
Untested.

https://stackoverflow.com/questions/19622198/what-does-set-e-mean-in-a-bash-script