### PR TITLE
Document required deps for local build

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ curl -fSsL https://raw.githubusercontent.com/nmlynch94/com.jagexlauncher.JagexLa
 - To update, run the above script again
 
 ### Build Locally (no automated updates)
-- Dependencies: `flatpak-builder`, `icoutils`, `imagemagick` 
+- Dependencies: [flatpak-builder](https://docs.flatpak.org/en/latest/flatpak-builder.html), [icoutils](https://www.nongnu.org/icoutils/), [imagemagick](https://imagemagick.org/#gsc.tab=0)
 - Clone the repo with submodules `git clone --recurse-submodules https://github.com/nmlynch94/com.jagexlauncher.JagexLauncher.git`
 - `cd com.jagexlauncher.JagexLauncher`
 - `cd icons && ./extract_icons.sh && cd ..`

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ curl -fSsL https://raw.githubusercontent.com/nmlynch94/com.jagexlauncher.JagexLa
 - To update, run the above script again
 
 ### Build Locally (no automated updates)
+- Dependencies: `flatpak-builder`, `icoutils`, `imagemagick` 
 - Clone the repo with submodules `git clone --recurse-submodules https://github.com/nmlynch94/com.jagexlauncher.JagexLauncher.git`
 - `cd com.jagexlauncher.JagexLauncher`
 - `cd icons && ./extract_icons.sh && cd ..`


### PR DESCRIPTION
While testing out the local build process, I found that I needed to install `icoutils`, and `flatpak-builder` in order to successfully build. Looks like imagemagick is another one that is required but I did have that installed already. I didn't see that build deps were listed in the README file so I thought I would document them in while I was going through the process